### PR TITLE
Some small cleanups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,14 @@ impl From<tables::CodeError> for ParserError {
     }
 }
 
-/// Represents a CEA-608 compatibility byte pair
+/// A CEA-608 compatibility byte pair
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Cea608 {
     Field1(u8, u8),
     Field2(u8, u8),
 }
 
+/// Parses a byte stream of `cc_data` bytes into indivdual [`DTVCCPacket`]s.
 #[derive(Debug, Default)]
 pub struct CCDataParser {
     pending_data: Vec<u8>,
@@ -92,8 +93,8 @@ impl CCDataParser {
     /// Will fail with [ParserError::LengthMismatch] if the length of the data does not match the
     /// number of cc triples specified in the `cc_data` header.
     ///
-    /// Ignores any CEA-608 data provided at the start of the data.  Any CEA-608 data provided
-    /// after valid CEA-708 data will return [ParserError::Cea608AfterCea708].
+    /// Any CEA-608 data provided after valid CEA-708 data will return
+    /// [ParserError::Cea608AfterCea708].
     pub fn push(&mut self, data: &[u8]) -> Result<(), ParserError> {
         trace!("parsing {data:?}");
         if let Some(ref mut cea608) = self.cea608 {
@@ -284,6 +285,7 @@ impl CCDataParser {
         ret
     }
 
+    /// Any [`Cea608`] bytes in the last parsed `cc_data`
     pub fn cea608(&mut self) -> Option<&[Cea608]> {
         if let Some(ref cea608) = self.cea608 {
             Some(cea608)
@@ -670,7 +672,7 @@ impl DTVCCPacket {
         Ok(Self { seq_no, services })
     }
 
-    /// Returns a copy of the [Service]s for this [DTVCCPacket]
+    /// The [Service]s for this [DTVCCPacket]
     pub fn services(&self) -> &[Service] {
         &self.services
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,7 @@ use std::time::Duration;
 
 use muldiv::MulDiv;
 
-#[macro_use]
-extern crate log;
+use log::{debug, trace, warn};
 
 pub mod tables;
 
@@ -1201,7 +1200,7 @@ mod test {
     fn cc_data_parse() {
         test_init_log();
         for (i, test_data) in TEST_CC_DATA.iter().enumerate() {
-            info!("parsing {i}: {test_data:?}");
+            log::info!("parsing {i}: {test_data:?}");
             let mut parser = CCDataParser::new();
             if !test_data.cea608.is_empty() {
                 parser.handle_cea608();
@@ -1488,7 +1487,7 @@ mod test {
     fn packet_write_cc_data() {
         test_init_log();
         for test_data in WRITE_CC_DATA.iter() {
-            info!("writing {test_data:?}");
+            log::info!("writing {test_data:?}");
             let mut packet_iter = test_data.packets.iter();
             let mut cea608_iter = test_data.cea608.iter();
             let mut writer = CCDataWriter::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,11 +287,7 @@ impl CCDataParser {
 
     /// Any [`Cea608`] bytes in the last parsed `cc_data`
     pub fn cea608(&mut self) -> Option<&[Cea608]> {
-        if let Some(ref cea608) = self.cea608 {
-            Some(cea608)
-        } else {
-            None
-        }
+        self.cea608.as_deref()
     }
 }
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -2038,6 +2038,7 @@ impl Ext1 {
 mod test {
     use super::*;
     use crate::tests::*;
+    use log::trace;
 
     #[test]
     fn codes_table_ordered() {


### PR DESCRIPTION
commit fe702f6df490362894331724594a4d5b2486cdd3

    reduce unnecessary indentation level

commit ba0232ce8f0777c1c55572603ada4ff3d320e0f9

    don't use #[macro_use] for log macros

commit cc6b4865a26af0de7a8374773b5efad831ae8b03

    use Option::as_deref() instead of open coding it

commit ed3d10dfcbddfd65985c334a1960e20026de619b

    a couple of doc fixes